### PR TITLE
Bugfix: Getting non direct attribute name

### DIFF
--- a/index.js
+++ b/index.js
@@ -822,7 +822,11 @@ var lighterhtml = (function (document,exports) {
     var cache = new Map$1();
     var attributes = node.attributes;
     var remove = [];
-    var array = remove.slice.call(attributes, 0);
+    var html = parts.join('');
+    // This is a fix for returning an ordered list of attributes (IE and Edge don't)
+    var array = remove.slice.call(attributes, 0).sort(function(left, right) {
+      return html.indexOf(left.name) <= html.indexOf(right.name) ? -1 : 1;
+    })
     var length = array.length;
     var i = 0;
 

--- a/index.js
+++ b/index.js
@@ -838,13 +838,14 @@ var lighterhtml = (function (document,exports) {
         /* istanbul ignore else */
 
         if (!cache.has(name)) {
-          var realName = parts.shift().replace(direct ? /^(?:|[\S\s]*?\s)(\S+?)\s*=\s*('|")?$/ : // TODO: while working on yet another IE/Edge bug I've realized
-          //        the current not direct logic easily breaks there
-          //        because the `name` might not be the real needed one.
-          //        Use a better RegExp to find last attribute instead
-          //        of trusting `name` is what we are looking for.
-          //        Thanks IE/Edge, I hate you both.
-          new RegExp('^(?:|[\\S\\s]*?\\s)(' + name + ')\\s*=\\s*(\'|")', 'i'), '$1');
+          var realName;
+          if (direct) {
+            realName = parts.shift().replace(/^(?:|[\S\s]*?\s)(\S+?)\s*=\s*('|")?$/, '$1');
+          } else {
+            var part = parts.shift();
+            var regex = new RegExp(`^(?:|[\\S\\s]*?\\s)(${name})\\s*=\\s*('|")`, 'i');
+            realName = part.replace(regex, '$1').replace(part.replace(regex, '$2').slice(1), '');
+          }
           var value = attributes[realName] || // the following ignore is covered by browsers
           // while basicHTML is already case-sensitive
 

--- a/index.js
+++ b/index.js
@@ -842,6 +842,7 @@ var lighterhtml = (function (document,exports) {
           if (direct) {
             realName = parts.shift().replace(/^(?:|[\S\s]*?\s)(\S+?)\s*=\s*('|")?$/, '$1');
           } else {
+            // TODO: improve current regex so that we don't need to use "replace" 3 times...
             var part = parts.shift();
             var regex = new RegExp(`^(?:|[\\S\\s]*?\\s)(${name})\\s*=\\s*('|")`, 'i');
             realName = part.replace(regex, '$1').replace(part.replace(regex, '$2').slice(1), '');


### PR DESCRIPTION
This PR fixes the bug on lighterhtml of matching the attribute name correctly when interpolated values are introduced.

Example of code that does not work before the fix:
```javascript
html`<div class="block__element${hasModifier ? '--modifier' : ''}"></div>`;
```