### PR TITLE
Fixed render() function second argument type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,10 @@ export interface Tag<T> extends TemplateFunction<Hole> {
 
 export declare const html: Tag<HTMLElement>;
 export declare const svg: Tag<SVGElement>;
+export type Renderable = Hole | HTMLElement | SVGElement;
 export declare function render<T extends Node>(
   node: T,
-  renderer: (() => Hole) | Hole,
+  renderer: (() => Renderable) | Renderable,
 ): T;
 export declare function custom(
   // TODO: This should be defined in `domtagger`


### PR DESCRIPTION
`render()` function accepts the following as a second argument:
- `Hole`;
- `HTMLElement`;
- `SVGElement`;
- callback returning any of the above.

This pull request fixes type definitions to reflect the current implementation.